### PR TITLE
docs(vue-css)

### DIFF
--- a/packages/demo/package-lock.json
+++ b/packages/demo/package-lock.json
@@ -8,14 +8,6 @@
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
       "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
-    },
-    "vue-lighthouse-viewer": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/vue-lighthouse-viewer/-/vue-lighthouse-viewer-0.0.7.tgz",
-      "integrity": "sha512-F4KLUto7gnRyzfwAgyIclgN/7AR/4tjQiqSi5n09hVAeg1y9wrBHhhGAM0mmvvUp2ykf4eVG/5dmUYJa9J4KMA==",
-      "requires": {
-        "vue": "^2.6.11"
-      }
     }
   }
 }

--- a/packages/vue-lighthouse-viewer/README.md
+++ b/packages/vue-lighthouse-viewer/README.md
@@ -1,12 +1,12 @@
 # vue-lighthouse-viewer
-This component is a Vue wrapper for the lighthouse-viewer for Vue. For now is using the sourcefiles
-from `lighthouse@next` (v6). It should be compatible with early reports from Lighthouse.
+This component is a Vue wrapper for the lighthouse-viewer. 
+It depends on [lighthouse-viewer](../lighthouse-viewer), package that exports the original lighthouse-viewer from Google
+as an ES modules package.
 
 ## Getting started
 1. Install using `npm install vue-lighthouse-viewer` or `yarn add vue-lighthouse-viewer`
 2. Import in your project:
 ```ts
-import "vue-lighthouse-viewer/dist/vuelighthouseviewer.css";
 import VueLighthouseViewer from "vue-lighthouse-viewer";
 ```
 3. Load the component in your code as follows:


### PR DESCRIPTION
Import the css manually is not longer needed. Updating the documentation.

Fixes #4 