### PR TITLE
fix: fixed types not being exported in lighthouse-viewer

### DIFF
--- a/packages/lighthouse-viewer/package.json
+++ b/packages/lighthouse-viewer/package.json
@@ -7,7 +7,8 @@
   "module": "./dist/lighthouse-viewer.es.js",
   "types": "./types/types.d.ts",
   "files": [
-    "/dist"
+    "/dist",
+    "/types"
   ],
   "exports": {
     ".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
       '@types/react': 17.0.39
       '@types/react-dom': 17.0.11
       '@vitejs/plugin-react': 1.1.4
-      lighthouse-viewer: ^0.1.64
+      lighthouse-viewer: ^0.1.65
       react: 17.0.2
       react-dom: 17.0.2
       typescript: 4.5.5
@@ -72,7 +72,7 @@ importers:
     specifiers:
       '@sveltejs/vite-plugin-svelte': 1.0.0-next.37
       '@tsconfig/svelte': 3.0.0
-      lighthouse-viewer: ^0.1.64
+      lighthouse-viewer: ^0.1.65
       svelte: 3.46.4
       svelte-check: 2.4.2
       svelte-preprocess: 4.10.2
@@ -92,7 +92,7 @@ importers:
 
   packages/vue-lighthouse-viewer:
     specifiers:
-      lighthouse-viewer: ^0.1.64
+      lighthouse-viewer: ^0.1.65
       typed-query-selector: 2.6.1
       typescript: 4.5.5
       vite: 2.7.13
@@ -107,6 +107,12 @@ importers:
       vite-plugin-vue2: 1.9.3_e3c37c0cfaae1b9f72ab6085139b0afb
       vue: 2.6.14
       vue-template-compiler: 2.6.14
+
+  test:
+    specifiers:
+      lighthouse-viewer: workspace:^0.1.65
+    dependencies:
+      lighthouse-viewer: link:../packages/lighthouse-viewer
 
   web/lighthouse-viewer:
     specifiers:


### PR DESCRIPTION
This PR adds the directory `types` to the list of directories packed and uploaded to npm.

Fixes #767 