### PR TITLE
fix: added noImplicitAny to tsconfig to help with types

### DIFF
--- a/packages/lighthouse-viewer/README.md
+++ b/packages/lighthouse-viewer/README.md
@@ -11,62 +11,22 @@ This is only for convenience, and it would be cool if some day the people from L
 
 1. Install it using `npm i lighthouse-viewer`
 2. In your code, import the following modules:
-```js
-import { DOM, ReportRenderer, ReportUIFeatures, Logger, template } from 'lighthouse-viewer';
-import reportJson from './report.json';
 
-const generateReport = (lighthouseReport) => {
-  const dom = new DOM(document);
-  const renderer = new ReportRenderer(dom);
-  const container = document.querySelector('main.lighthouse-viewer');
-  renderer.renderReport(lighthouseReport, container);
-  const features = new ReportUIFeatures(dom);
-  features.initFeatures(lighthouseReport);
-};
+```ts
+import { renderReport } from 'lighthouse-viewer';
+import report from './static/report.json';
 
-const mountViewer = () => {
-  const htmlTemplate = document.createElement('div');
-  htmlTemplate.innerHTML = template;
-  const htmlTemplateElement = document.getElementById('html-template');
-  if (htmlTemplateElement) {
-    htmlTemplateElement.appendChild(htmlTemplate);
+const app = document.querySelector<HTMLDivElement>('#lighthouse-viewer-element')!;
 
-    document.addEventListener('lh-log', (e) => {
-      const lhLogElement = document.querySelector('#lh-log');
-      if (lhLogElement) {
-        const logger = new Logger(lhLogElement);
-        switch (e.detail.cmd) {
-          case 'log':
-            logger.log(e.detail.msg);
-            break;
-          case 'warn':
-            logger.warn(e.detail.msg);
-            break;
-          case 'error':
-            logger.error(e.detail.msg);
-            break;
-          case 'hide':
-            logger.hide();
-            break;
-          default:
-        }
-      }
-    });
-  }
-
-  generateReport(reportJson);
-};
-
-mountViewer();
+const reportHtml = renderReport(report as any, {});
+app.appendChild(reportHtml);
 ```
+
 3. And in your HTML
+
 ```html
 <div>
-    <div class="lh-root lh-vars">
-        <div id="html-template"></div>
-        <main class="lighthouse-viewer"></main>
-        <div id="lh-log"></div>
-    </div>
+  <main class="lighthouse-viewer"></main>
 </div>
 ```
 ## All the credits to the Lightouse Authors

--- a/packages/lighthouse-viewer/package.json
+++ b/packages/lighthouse-viewer/package.json
@@ -38,7 +38,7 @@
     "dev": "vite",
     "build:demo": "tsc && vite build",
     "build:lib": "cross-env BUILD_TYPE=library vite build && tsc --project tsconfig.lib.json",
-    "build": "npm run build:demo && npm run build:lib",
+    "build": "pnpm build:demo && pnpm build:lib",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/packages/lighthouse-viewer/tsconfig.base.json
+++ b/packages/lighthouse-viewer/tsconfig.base.json
@@ -11,7 +11,8 @@
       "esModuleInterop": true,
       "noUnusedLocals": true,
       "noUnusedParameters": true,
-      "noImplicitReturns": true
+      "noImplicitReturns": true,
+      "noImplicitAny": false,
     },
     "references": [
       {"path": "node_modules/lighthouse/types/lhr/"},

--- a/packages/react2-lighthouse-viewer/package.json
+++ b/packages/react2-lighthouse-viewer/package.json
@@ -36,7 +36,7 @@
     "dev": "vite",
     "build:demo": "tsc && vite build",
     "build:lib": "cross-env BUILD_TYPE=library vite build && tsc --project tsconfig.lib.json",
-    "build": "npm run build:demo && npm run build:lib",
+    "build": "pnpm build:demo && pnpm build:lib",
     "preview": "vite preview"
   },
   "peerDependencies": {

--- a/packages/react2-lighthouse-viewer/tsconfig.base.json
+++ b/packages/react2-lighthouse-viewer/tsconfig.base.json
@@ -13,7 +13,8 @@
     "moduleResolution": "Node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "noImplicitAny": false
   },
   "include": ["./src", "./lib/"]
 }

--- a/packages/svelte-lighthouse-viewer/package.json
+++ b/packages/svelte-lighthouse-viewer/package.json
@@ -38,7 +38,7 @@
     "dev": "vite",
     "build:demo": "tsc && vite build",
     "build:lib": "cross-env BUILD_TYPE=library vite build && tsc --project tsconfig.lib.json",
-    "build": "npm run build:demo && npm run build:lib",
+    "build": "pnpm build:demo && pnpm build:lib",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },

--- a/packages/svelte-lighthouse-viewer/tsconfig.base.json
+++ b/packages/svelte-lighthouse-viewer/tsconfig.base.json
@@ -13,7 +13,8 @@
      * of JS in `.svelte` files.
      */
     "allowJs": true,
-    "checkJs": true
+    "checkJs": true,
+    "noImplicitAny": false
   },
   "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"]
 }

--- a/packages/vue-lighthouse-viewer/package.json
+++ b/packages/vue-lighthouse-viewer/package.json
@@ -37,7 +37,7 @@
     "dev": "vite",
     "build:demo": "tsc && vite build",
     "build:lib": "cross-env BUILD_TYPE=library vite build && tsc --project tsconfig.lib.json",
-    "build": "npm run build:demo && npm run build:lib",
+    "build": "pnpm build:demo && pnpm build:lib",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/packages/vue-lighthouse-viewer/tsconfig.base.json
+++ b/packages/vue-lighthouse-viewer/tsconfig.base.json
@@ -11,11 +11,7 @@
       "esModuleInterop": true,
       "noUnusedLocals": true,
       "noUnusedParameters": true,
-      "noImplicitReturns": true
-    },
-    "references": [
-      {"path": "node_modules/lighthouse/types/lhr/"},
-      {"path": "node_modules/lighthouse/report/generator/"},
-      {"path": "node_modules/lighthouse/shared/"}
-    ],
+      "noImplicitReturns": true,
+      "noImplicitAny": false
+    }
   }


### PR DESCRIPTION
The original lighthouse library is not fully typed using typescript.

There are several dependencies to Javascript files with JSDoc, and some of them are not complete. This causes the TypeScript compiler to fail.

Example:

```ts
// node_modules/lighthouse/report/types/report-renderer.d.ts
import { Result as AuditResult } from "../../types/lhr/audit-result";
import { ReportUIFeatures } from "../renderer/report-ui-features.js";
```

```ts
// node_modules/lighthouse/report/renderer/report-ui-features.js
import {getLhrFilenamePrefix} from '../generator/file-namer.js';
```

By adding the noImplicitAny we can bypass this.

This is a workaround and I should find a way to load the types in a better way.