### PR TITLE
chore: added types to export field

### DIFF
--- a/packages/lighthouse-viewer/package.json
+++ b/packages/lighthouse-viewer/package.json
@@ -13,7 +13,8 @@
   "exports": {
     ".": {
       "import": "./dist/lighthouse-viewer.es.js",
-      "require": "./dist/lighthouse-viewer.umd.js"
+      "require": "./dist/lighthouse-viewer.umd.js",
+      "types": "./types/types.d.ts"
     }
   },
   "license": "Apache-2.0",

--- a/packages/react2-lighthouse-viewer/package.json
+++ b/packages/react2-lighthouse-viewer/package.json
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "import": "./dist/react2-lighthouse-viewer.es.js",
-      "require": "./dist/react2-lighthouse-viewer.umd.js"
+      "require": "./dist/react2-lighthouse-viewer.umd.js",
+      "types": "./dist/main.d.ts"
     }
   },
   "license": "Apache-2.0",

--- a/packages/svelte-lighthouse-viewer/package.json
+++ b/packages/svelte-lighthouse-viewer/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "import": "./dist/svelte-lighthouse-viewer.es.js",
-      "require": "./dist/svelte-lighthouse-viewer.umd.js"
+      "require": "./dist/svelte-lighthouse-viewer.umd.js",
+      "types": "./dist/main.d.ts"
     }
   },
   "license": "Apache-2.0",

--- a/packages/vue-lighthouse-viewer/package.json
+++ b/packages/vue-lighthouse-viewer/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "import": "./dist/vue-lighthouse-viewer.es.js",
-      "require": "./dist/vue-lighthouse-viewer.umd.js"
+      "require": "./dist/vue-lighthouse-viewer.umd.js",
+      "types": "./types/types.d.ts"
     }
   },
   "license": "Apache-2.0",

--- a/packages/vue3-lighthouse-viewer/package.json
+++ b/packages/vue3-lighthouse-viewer/package.json
@@ -13,7 +13,8 @@
   "exports": {
     ".": {
       "import": "./dist/vue-lighthouse-viewer.es.js",
-      "require": "./dist/vue-lighthouse-viewer.umd.js"
+      "require": "./dist/vue-lighthouse-viewer.umd.js",
+      "types": "./types/types.d.ts"
     }
   },
   "license": "Apache-2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
         specifier: 5.0.1
         version: 5.0.1(@babel/plugin-syntax-flow@7.18.6(@babel/core@7.21.0))(@babel/plugin-transform-react-jsx@7.21.0(@babel/core@7.21.0))(@types/babel__core@7.20.5)(eslint@9.17.0(jiti@1.21.7))(react@18.2.0)(type-fest@4.35.0)(typescript@5.7.3)(vue-template-compiler@2.7.16)
       react2-lighthouse-viewer:
-        specifier: workspace:0.2.109
+        specifier: workspace:0.2.110
         version: link:../../packages/react2-lighthouse-viewer
       web-vitals:
         specifier: 2.1.4
@@ -142,7 +142,7 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       react2-lighthouse-viewer:
-        specifier: workspace:0.2.109
+        specifier: workspace:0.2.110
         version: link:../../packages/react2-lighthouse-viewer
       typescript:
         specifier: 5.7.2
@@ -170,7 +170,7 @@ importers:
         specifier: 4.7.0
         version: 4.7.0(vite@6.0.11(@types/node@24.3.3)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0))
       lighthouse-viewer:
-        specifier: workspace:^0.2.109
+        specifier: workspace:^0.2.110
         version: link:../lighthouse-viewer
       react:
         specifier: 19.0.0
@@ -188,7 +188,7 @@ importers:
         specifier: 5.0.5
         version: 5.0.5
       lighthouse-viewer:
-        specifier: workspace:^0.2.109
+        specifier: workspace:^0.2.110
         version: link:../lighthouse-viewer
       svelte:
         specifier: 5.25.12
@@ -206,7 +206,7 @@ importers:
         specifier: 2.3.3
         version: 2.3.3(vite@6.0.11(@types/node@24.3.3)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0))(vue@2.7.16)
       lighthouse-viewer:
-        specifier: workspace:^0.2.109
+        specifier: workspace:^0.2.110
         version: link:../lighthouse-viewer
       vue:
         specifier: 2.7.16
@@ -224,7 +224,7 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(typescript@5.7.3)(vue@3.5.21(typescript@5.7.3))
       lighthouse-viewer:
-        specifier: workspace:^0.2.109
+        specifier: workspace:^0.2.110
         version: link:../lighthouse-viewer
       typescript:
         specifier: 5.7.3
@@ -245,10 +245,10 @@ importers:
         specifier: 8.0.0
         version: 8.0.0
       react2-lighthouse-viewer:
-        specifier: workspace:^0.2.109
+        specifier: workspace:^0.2.110
         version: link:../../packages/react2-lighthouse-viewer
       svelte-lighthouse-viewer:
-        specifier: workspace:^0.2.109
+        specifier: workspace:^0.2.110
         version: link:../../packages/svelte-lighthouse-viewer
       typescript:
         specifier: 5.7.3
@@ -257,10 +257,10 @@ importers:
         specifier: 6.0.11
         version: 6.0.11(@types/node@24.3.3)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0)
       vue-lighthouse-viewer:
-        specifier: workspace:^0.2.109
+        specifier: workspace:^0.2.110
         version: link:../../packages/vue-lighthouse-viewer
       vue3-lighthouse-viewer:
-        specifier: workspace:^0.1.110
+        specifier: workspace:^0.1.111
         version: link:../../packages/vue3-lighthouse-viewer
 
 packages:


### PR DESCRIPTION
This PR adds the missing types to the package export fields
This pull request updates the `exports` fields in several package manifests to include TypeScript type definitions, improving type support for consumers. It also bumps the workspace version references for these packages in `pnpm-lock.yaml`, ensuring all dependencies are aligned with the latest versions.

**TypeScript support improvements:**

* Added a `types` field to the `exports` entry in `package.json` for `lighthouse-viewer`, `vue-lighthouse-viewer`, and `vue3-lighthouse-viewer`, pointing to `./types/types.d.ts` for type definitions. [[1]](diffhunk://#diff-770f869cab49bc16554aa8126ef25a5d65ac9617afe4c82a7b8ce3921afd7fd2L16-R17) [[2]](diffhunk://#diff-dac3d73e6a58a5f7485883defcf51ef1c1d733dab035d213be23880f2c0f53aaL15-R16) [[3]](diffhunk://#diff-43bc269e761508d797f56f404c69886f48c71c3560fe32ddcafa457744bb532aL16-R17)
* Added a `types` field to the `exports` entry in `package.json` for `react2-lighthouse-viewer` and `svelte-lighthouse-viewer`, pointing to `./dist/main.d.ts` for type definitions. [[1]](diffhunk://#diff-31523324b49be8e5cf8aa5497f4a09884c42aca28fcf5c043c44a003875cd3e3L14-R15) [[2]](diffhunk://#diff-fef03b51c7c90384d5560610b977cb90e8272a431d742fcd54eb04a6003282e1L15-R16)

**Dependency and workspace version updates:**

* Updated workspace version references for `lighthouse-viewer`, `react2-lighthouse-viewer`, `svelte-lighthouse-viewer`, `vue-lighthouse-viewer`, and `vue3-lighthouse-viewer` in `pnpm-lock.yaml` to the latest patch versions. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL99-R99) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL145-R145) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL173-R173) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL191-R191) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL209-R209) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL227-R227) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL248-R251) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL260-R263)